### PR TITLE
Address Issue #16.

### DIFF
--- a/lib/set-inner-html-ast.js
+++ b/lib/set-inner-html-ast.js
@@ -1,15 +1,18 @@
-let parse = require('@babel/core').parse
-let escapeTemplateLiteral = string => string.replace(/`/g, '\\`').replace(/\\/g, '\\\\')
+let escapeTemplateLiteral = string => string.replace(/\\/g, '\\\\').replace(/`/g, '\\`')
 
 let viaShadow = (innerHTML, stylesText) => {
-  return parse(`
-    this.attachShadow({mode: 'open'});
-    this.shadowRoot.innerHTML = \`${escapeTemplateLiteral(innerHTML)}${
-  stylesText
-    ? `<style>${escapeTemplateLiteral(stylesText)}</style>`
-    : ''
-}\`;
-  `).program.body
+  try {
+    let styleTag = stylesText
+      ? `<style>${escapeTemplateLiteral(stylesText)}</style>`
+      : ''
+
+    return require('@babel/core').parse(`
+      this.attachShadow({mode: 'open'});
+      this.shadowRoot.innerHTML = \`${escapeTemplateLiteral(innerHTML)}${styleTag}\`;
+    `).program.body
+  } catch (error) {
+    require('./fail')(`Problem generating innerHTML AST for shadowRoot. ${error}`)
+  }
 }
 
 let withOneSlot = innerHTML => {

--- a/lib/transform-script-text.js
+++ b/lib/transform-script-text.js
@@ -96,7 +96,7 @@ let parseStyles = stylesText => {
       chalk.white(errorLines[error.line - 4] || ''),
       chalk.white(errorLines[error.line - 3] || ''),
       chalk.white(errorLines[error.line - 2] || ''),
-      chalk.red(errorLines[error.line - 1]), // the offending lin,
+      chalk.red(errorLines[error.line - 1]), // the offending line,
       chalk.white(errorLines[error.line] || ''),
       chalk.white(errorLines[error.line + 1] || ''),
       chalk.white(errorLines[error.line + 2] || ''),

--- a/test/dist/concentric-blocks.class.js
+++ b/test/dist/concentric-blocks.class.js
@@ -31,6 +31,8 @@ class ConcentricBlocks extends HTMLElement {
   width: 25px;
 }
 
+/* Testing \`:host(::after)\` bug. It should output \`:host::after\`. */
+
 :host(:hover) {
   background-color: #9f11bb;
 }

--- a/test/dist/concentric-blocks.es5.js
+++ b/test/dist/concentric-blocks.es5.js
@@ -53,7 +53,7 @@ function (_HTMLElement) {
 
 (function () {
   var style = document.createElement('style');
-  style.textContent = 'concentric-blocks {  display: inline-block;  background-color: #001199;  height: 100px;  position: relative;  width: 100px;}concentric-blocks div {  background-color: #ff9911;  height: 25px;  left: 25px;  position: absolute;  top: 25px;  width: 25px;}concentric-blocks span {  background-color: #ff9911;  height: 25px;  left: 50px;  position: absolute;  top: 50px;  width: 25px;}concentric-blocks:hover {  background-color: #9f11bb;}concentric-blocks::after {  background-color: #ff9911;  content: \'!\';  height: 25px;  left: 0;  line-height: 25px;  position: absolute;  text-align: center;  top: 0;  width: 25px;}';
+  style.textContent = 'concentric-blocks {  display: inline-block;  background-color: #001199;  height: 100px;  position: relative;  width: 100px;}concentric-blocks div {  background-color: #ff9911;  height: 25px;  left: 25px;  position: absolute;  top: 25px;  width: 25px;}concentric-blocks span {  background-color: #ff9911;  height: 25px;  left: 50px;  position: absolute;  top: 50px;  width: 25px;}/* Testing `:host(::after)` bug. It should output `:host::after`. */concentric-blocks:hover {  background-color: #9f11bb;}concentric-blocks::after {  background-color: #ff9911;  content: \'!\';  height: 25px;  left: 0;  line-height: 25px;  position: absolute;  text-align: center;  top: 0;  width: 25px;}';
   document.head.appendChild(style);
 })();
 

--- a/test/src/post-css/concentric-blocks.css
+++ b/test/src/post-css/concentric-blocks.css
@@ -30,6 +30,7 @@
   }
 }
 
+/* Testing `:host(::after)` bug. It should output `:host::after`. */
 concentric-blocks {
   &:hover {
     background-color: var(--purple);


### PR DESCRIPTION
Properly escape backwhacks in CSS so they don't break on babel parse of
inserting a <style> into the innerHTML of the shadowRoot.
Complain better about how parsing fails in that case.
Typo fix.
Bugfix version bump.