### PR TITLE
When an ES6 AST is being generated, and no innerHTML is provided,

### DIFF
--- a/lib/set-inner-html-ast.js
+++ b/lib/set-inner-html-ast.js
@@ -1,6 +1,10 @@
 let escapeTemplateLiteral = string => string.replace(/\\/g, '\\\\').replace(/`/g, '\\`')
 
 let viaShadow = (innerHTML, stylesText) => {
+  let escapedInnerHTML = innerHTML
+    ? escapeTemplateLiteral(innerHTML)
+    : '<slot></slot>' // Otherwise simple elements that are styles-only wouldn't style their guts.
+
   try {
     let styleTag = stylesText
       ? `<style>${escapeTemplateLiteral(stylesText)}</style>`
@@ -8,7 +12,7 @@ let viaShadow = (innerHTML, stylesText) => {
 
     return require('@babel/core').parse(`
       this.attachShadow({mode: 'open'});
-      this.shadowRoot.innerHTML = \`${escapeTemplateLiteral(innerHTML)}${styleTag}\`;
+      this.shadowRoot.innerHTML = \`${escapedInnerHTML}${styleTag}\`;
     `).program.body
   } catch (error) {
     require('./fail')(`Problem generating innerHTML AST for shadowRoot. ${error}`)

--- a/lib/transform-script-text.js
+++ b/lib/transform-script-text.js
@@ -180,19 +180,13 @@ module.exports = (scriptText, tagName, className, innerHTML, stylesText) => {
 
     if (innerHTML) {
       mutateES5Class(es5Ast, tagName, className, innerHTML)
-      if (stylesText) {
-        es5Ast.program.body.push(appendStyleAst(elementNameStyles(tagName, stylesText)))
-      }
-
-      addShadowDomAliases(es6Ast, className)
-      mutateES6ConnectedCallback(es6Ast, className, innerHTML, shadowDomStyles(tagName, stylesText))
-    } else if (stylesText) {
-      es5Ast.program.body.push(appendStyleAst(elementNameStyles(tagName, stylesText)))
-
-      // If there's no innerHTML then we'll just use the es5-style of elementName styles being attached to document.head,
-      // because there's now shadowDOM for :host selectors to style.
-      es6Ast.program.body.push(appendStyleAst(elementNameStyles(tagName, stylesText)))
     }
+    if (stylesText) {
+      es5Ast.program.body.push(appendStyleAst(elementNameStyles(tagName, stylesText)))
+    }
+
+    addShadowDomAliases(es6Ast, className) // One would think these aren't necessary without innerHTML, but for no-surprises principle, put 'em on there.
+    mutateES6ConnectedCallback(es6Ast, className, innerHTML, shadowDomStyles(tagName, stylesText))
 
     es5Ast.program.body.push(defineCustomElement.es5(className, tagName))
     es6Ast.program.body.push(defineCustomElement.es6(className, tagName))

--- a/test/demo/es5.html
+++ b/test/demo/es5.html
@@ -82,6 +82,9 @@
   <p><code>&lt;checker-blocks&gt;&lt;/checker-blocks&gt;</code></p>
   <checker-blocks></checker-blocks>
 
+  <p><code>&lt;multi-square&gt;&lt;/multi-square&gt;</code></p>
+  <multi-square></multi-square>
+
   <p><code>&lt;deep-purple&gt;Deep Purple&lt;/deep-purple&gt;</code></p>
   <deep-purple>Deep Purple</deep-purple>
 

--- a/test/demo/es6.html
+++ b/test/demo/es6.html
@@ -80,6 +80,9 @@
   <p><code>&lt;checker-blocks&gt;&lt;/checker-blocks&gt;</code></p>
   <checker-blocks></checker-blocks>
 
+  <p><code>&lt;multi-square&gt;&lt;/multi-square&gt;</code></p>
+  <multi-square></multi-square>
+
   <p><code>&lt;deep-purple&gt;Deep Purple&lt;/deep-purple&gt;</code></p>
   <deep-purple>Deep Purple</deep-purple>
 

--- a/test/dist/blue-square.class.js
+++ b/test/dist/blue-square.class.js
@@ -1,15 +1,14 @@
-class HighLight extends HTMLElement {
+class BlueSquare extends HTMLElement {
   connectedCallback() {
     this.attachShadow({
       mode: 'open'
     });
-    this.shadowRoot.innerHTML = `<slot></slot><style>/**
-This file is intended to test the watcher functionality.
-Change the background-color and see if your page automatically refreshes.
-**/
-
-:host {
-  background-color: yellow;
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: blue;
+  opacity: 0.4;
+  display: inline-block;
+  width: 30px;
+  height: 30px;
 }</style>`;
   }
 
@@ -27,4 +26,4 @@ Change the background-color and see if your page automatically refreshes.
 
 }
 
-customElements.define('high-light', HighLight);
+customElements.define('blue-square', BlueSquare);

--- a/test/dist/blue-square.es5.js
+++ b/test/dist/blue-square.es5.js
@@ -1,0 +1,62 @@
+"use strict";
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+
+function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+
+function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+var BlueSquare =
+/*#__PURE__*/
+function (_HTMLElement) {
+  _inherits(BlueSquare, _HTMLElement);
+
+  function BlueSquare() {
+    _classCallCheck(this, BlueSquare);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(BlueSquare).apply(this, arguments));
+  }
+
+  _createClass(BlueSquare, [{
+    key: "connectedCallback",
+    value: function connectedCallback() {}
+  }]);
+
+  return BlueSquare;
+}(_wrapNativeSuper(HTMLElement));
+
+"use strict";
+
+;
+
+(function () {
+  var style = document.createElement('style');
+  style.textContent = 'blue-square {  background-color: blue;  opacity: 0.4;  display: inline-block;  width: 30px;  height: 30px;}';
+  document.head.appendChild(style);
+})();
+
+"use strict";
+
+window.addEventListener('WebComponentsReady', function () {
+  customElements.define('blue-square', BlueSquare);
+});

--- a/test/dist/bundle.class.js
+++ b/test/dist/bundle.class.js
@@ -63,6 +63,36 @@ class BlueButton extends HTMLElement {
 
 customElements.define('blue-button', BlueButton);
 
+class BlueSquare extends HTMLElement {
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: blue;
+  opacity: 0.4;
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+}</style>`;
+  }
+
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
+
+customElements.define('blue-square', BlueSquare);
+
 class IPad extends HTMLElement {
   connectedCallback() {
     this.attachShadow({
@@ -134,6 +164,49 @@ class LoginForm extends HTMLElement {
 }
 
 customElements.define('login-form', LoginForm);
+
+class MultiSquare extends HTMLElement {
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `
+  <blue-square></blue-square>
+  <red-square></red-square>
+<style>:host {
+  display: inline-block;
+  width: 45px;
+  height: 30px;
+  position: relative;
+}
+
+:host blue-square,
+:host red-square {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+:host blue-square {
+  left: 15px;
+}</style>`;
+  }
+
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
+
+customElements.define('multi-square', MultiSquare);
 
 class MyHeart extends HTMLElement {
   connectedCallback() {
@@ -311,17 +384,38 @@ class NameTag extends HTMLElement {
 customElements.define('name-tag', NameTag);
 
 class PillText2 extends HTMLElement {
-  connectedCallback() {}
-
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: #80ff80;
+  border-radius: 1em;
+  padding-left: 0.5em;
 }
 
-;
+:host::after {
+  background-color: #ffd076;
+  content: "!";
+  display: inline-block;
+  width: 1.5em;
+  text-align: center;
+}</style>`;
+  }
 
-(function () {
-  var style = document.createElement('style');
-  style.textContent = 'pill-text-2 {  background-color: #80ff80;  border-radius: 1em;  padding-left: 0.5em;}pill-text-2::after {  background-color: #ffd076;  content: "!";  display: inline-block;  width: 1.5em;  text-align: center;}';
-  document.head.appendChild(style);
-})();
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
 
 customElements.define('pill-text-2', PillText2);
 
@@ -449,6 +543,36 @@ class RadioButton extends HTMLElement {
 }
 
 customElements.define('radio-button', RadioButton);
+
+class RedSquare extends HTMLElement {
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: red;
+  opacity: 0.4;
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+}</style>`;
+  }
+
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
+
+customElements.define('red-square', RedSquare);
 
 class StarRating extends HTMLElement {
   connectedCallback() {

--- a/test/dist/bundle.es5.js
+++ b/test/dist/bundle.es5.js
@@ -140,6 +140,43 @@ window.addEventListener('WebComponentsReady', function () {
 
 "use strict";
 
+var BlueSquare =
+/*#__PURE__*/
+function (_HTMLElement) {
+  _inherits(BlueSquare, _HTMLElement);
+
+  function BlueSquare() {
+    _classCallCheck(this, BlueSquare);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(BlueSquare).apply(this, arguments));
+  }
+
+  _createClass(BlueSquare, [{
+    key: "connectedCallback",
+    value: function connectedCallback() {}
+  }]);
+
+  return BlueSquare;
+}(_wrapNativeSuper(HTMLElement));
+
+"use strict";
+
+;
+
+(function () {
+  var style = document.createElement('style');
+  style.textContent = 'blue-square {  background-color: blue;  opacity: 0.4;  display: inline-block;  width: 30px;  height: 30px;}';
+  document.head.appendChild(style);
+})();
+
+"use strict";
+
+window.addEventListener('WebComponentsReady', function () {
+  customElements.define('blue-square', BlueSquare);
+});
+
+"use strict";
+
 var IPad =
 /*#__PURE__*/
 function (_HTMLElement) {
@@ -257,6 +294,45 @@ function (_HTMLElement) {
 
 window.addEventListener('WebComponentsReady', function () {
   customElements.define('login-form', LoginForm);
+});
+
+"use strict";
+
+var MultiSquare =
+/*#__PURE__*/
+function (_HTMLElement) {
+  _inherits(MultiSquare, _HTMLElement);
+
+  function MultiSquare() {
+    _classCallCheck(this, MultiSquare);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(MultiSquare).apply(this, arguments));
+  }
+
+  _createClass(MultiSquare, [{
+    key: "connectedCallback",
+    value: function connectedCallback() {
+      this.innerHTML = "\n  <blue-square></blue-square>\n  <red-square></red-square>\n";
+    }
+  }]);
+
+  return MultiSquare;
+}(_wrapNativeSuper(HTMLElement));
+
+"use strict";
+
+;
+
+(function () {
+  var style = document.createElement('style');
+  style.textContent = 'multi-square {  display: inline-block;  width: 45px;  height: 30px;  position: relative;}multi-square blue-square,multi-square red-square {  position: absolute;  left: 0;  top: 0;}multi-square blue-square {  left: 15px;}';
+  document.head.appendChild(style);
+})();
+
+"use strict";
+
+window.addEventListener('WebComponentsReady', function () {
+  customElements.define('multi-square', MultiSquare);
 });
 
 "use strict";
@@ -449,6 +525,43 @@ function (_HTMLElement) {
 
 window.addEventListener('WebComponentsReady', function () {
   customElements.define('radio-button', RadioButton);
+});
+
+"use strict";
+
+var RedSquare =
+/*#__PURE__*/
+function (_HTMLElement) {
+  _inherits(RedSquare, _HTMLElement);
+
+  function RedSquare() {
+    _classCallCheck(this, RedSquare);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(RedSquare).apply(this, arguments));
+  }
+
+  _createClass(RedSquare, [{
+    key: "connectedCallback",
+    value: function connectedCallback() {}
+  }]);
+
+  return RedSquare;
+}(_wrapNativeSuper(HTMLElement));
+
+"use strict";
+
+;
+
+(function () {
+  var style = document.createElement('style');
+  style.textContent = 'red-square {  background-color: red;  opacity: 0.4;  display: inline-block;  width: 30px;  height: 30px;}';
+  document.head.appendChild(style);
+})();
+
+"use strict";
+
+window.addEventListener('WebComponentsReady', function () {
+  customElements.define('red-square', RedSquare);
 });
 
 "use strict";

--- a/test/dist/deep-purple.class.js
+++ b/test/dist/deep-purple.class.js
@@ -1,14 +1,29 @@
 class DeepPurple extends HTMLElement {
-  connectedCallback() {}
-
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: purple;
 }
 
-;
+:host {
+  color: white;
+}</style>`;
+  }
 
-(function () {
-  var style = document.createElement('style');
-  style.textContent = 'deep-purple {  background-color: purple;}deep-purple {  color: white;}';
-  document.head.appendChild(style);
-})();
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
 
 customElements.define('deep-purple', DeepPurple);

--- a/test/dist/inner-logger.class.js
+++ b/test/dist/inner-logger.class.js
@@ -5,6 +5,10 @@ class InnerLogger extends HTMLElement {
   }
 
   connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot>`;
     Object.assign(this.style, {
       fontFamily: `"Courier New", Courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace`,
       color: 'green',
@@ -14,6 +18,18 @@ class InnerLogger extends HTMLElement {
     this.addEventListener('click', event => {
       console.log('click event!', event);
     });
+  }
+
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
   }
 
 }

--- a/test/dist/multi-square.class.js
+++ b/test/dist/multi-square.class.js
@@ -1,0 +1,42 @@
+class MultiSquare extends HTMLElement {
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `
+  <blue-square></blue-square>
+  <red-square></red-square>
+<style>:host {
+  display: inline-block;
+  width: 45px;
+  height: 30px;
+  position: relative;
+}
+
+:host blue-square,
+:host red-square {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+:host blue-square {
+  left: 15px;
+}</style>`;
+  }
+
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
+
+customElements.define('multi-square', MultiSquare);

--- a/test/dist/multi-square.es5.js
+++ b/test/dist/multi-square.es5.js
@@ -1,0 +1,64 @@
+"use strict";
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+
+function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+
+function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+var MultiSquare =
+/*#__PURE__*/
+function (_HTMLElement) {
+  _inherits(MultiSquare, _HTMLElement);
+
+  function MultiSquare() {
+    _classCallCheck(this, MultiSquare);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(MultiSquare).apply(this, arguments));
+  }
+
+  _createClass(MultiSquare, [{
+    key: "connectedCallback",
+    value: function connectedCallback() {
+      this.innerHTML = "\n  <blue-square></blue-square>\n  <red-square></red-square>\n";
+    }
+  }]);
+
+  return MultiSquare;
+}(_wrapNativeSuper(HTMLElement));
+
+"use strict";
+
+;
+
+(function () {
+  var style = document.createElement('style');
+  style.textContent = 'multi-square {  display: inline-block;  width: 45px;  height: 30px;  position: relative;}multi-square blue-square,multi-square red-square {  position: absolute;  left: 0;  top: 0;}multi-square blue-square {  left: 15px;}';
+  document.head.appendChild(style);
+})();
+
+"use strict";
+
+window.addEventListener('WebComponentsReady', function () {
+  customElements.define('multi-square', MultiSquare);
+});

--- a/test/dist/pill-text-2.class.js
+++ b/test/dist/pill-text-2.class.js
@@ -1,14 +1,35 @@
 class PillText2 extends HTMLElement {
-  connectedCallback() {}
-
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: #80ff80;
+  border-radius: 1em;
+  padding-left: 0.5em;
 }
 
-;
+:host::after {
+  background-color: #ffd076;
+  content: "!";
+  display: inline-block;
+  width: 1.5em;
+  text-align: center;
+}</style>`;
+  }
 
-(function () {
-  var style = document.createElement('style');
-  style.textContent = 'pill-text-2 {  background-color: #80ff80;  border-radius: 1em;  padding-left: 0.5em;}pill-text-2::after {  background-color: #ffd076;  content: "!";  display: inline-block;  width: 1.5em;  text-align: center;}';
-  document.head.appendChild(style);
-})();
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
 
 customElements.define('pill-text-2', PillText2);

--- a/test/dist/pill-text.class.js
+++ b/test/dist/pill-text.class.js
@@ -1,14 +1,35 @@
 class PillText extends HTMLElement {
-  connectedCallback() {}
-
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: #8080ff;
+  border-radius: 1em;
+  padding-left: 0.5em;
 }
 
-;
+:host::after {
+  background-color: #ff8080;
+  content: "?";
+  display: inline-block;
+  width: 1.5em;
+  text-align: center;
+}</style>`;
+  }
 
-(function () {
-  var style = document.createElement('style');
-  style.textContent = 'pill-text {  background-color: #8080ff;  border-radius: 1em;  padding-left: 0.5em;}pill-text::after {  background-color: #ff8080;  content: "?";  display: inline-block;  width: 1.5em;  text-align: center;}';
-  document.head.appendChild(style);
-})();
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
 
 customElements.define('pill-text', PillText);

--- a/test/dist/pseudo-blocks.class.js
+++ b/test/dist/pseudo-blocks.class.js
@@ -1,14 +1,49 @@
 class PseudoBlocks extends HTMLElement {
-  connectedCallback() {}
-
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  display: inline-block;
+  background-color: rgb(8, 223, 16);
+  height: 100px;
+  position: relative;
+  width: 100px;
 }
 
-;
+:host::after {
+  background-color: rgb(255, 239, 16);
+  content: '';
+  height: 25px;
+  left: 25px;
+  position: absolute;
+  top: 25px;
+  width: 25px;
+}
 
-(function () {
-  var style = document.createElement('style');
-  style.textContent = 'pseudo-blocks {  display: inline-block;  background-color: rgb(8, 223, 16);  height: 100px;  position: relative;  width: 100px;}pseudo-blocks::after {  background-color: rgb(255, 239, 16);  content: \'\';  height: 25px;  left: 25px;  position: absolute;  top: 25px;  width: 25px;}pseudo-blocks::before {  background-color: rgb(255, 239, 16);  content: \'\';  height: 25px;  left: 50px;  position: absolute;  top: 50px;  width: 25px;}';
-  document.head.appendChild(style);
-})();
+:host::before {
+  background-color: rgb(255, 239, 16);
+  content: '';
+  height: 25px;
+  left: 50px;
+  position: absolute;
+  top: 50px;
+  width: 25px;
+}</style>`;
+  }
+
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
 
 customElements.define('pseudo-blocks', PseudoBlocks);

--- a/test/dist/red-square.class.js
+++ b/test/dist/red-square.class.js
@@ -1,15 +1,14 @@
-class HighLight extends HTMLElement {
+class RedSquare extends HTMLElement {
   connectedCallback() {
     this.attachShadow({
       mode: 'open'
     });
-    this.shadowRoot.innerHTML = `<slot></slot><style>/**
-This file is intended to test the watcher functionality.
-Change the background-color and see if your page automatically refreshes.
-**/
-
-:host {
-  background-color: yellow;
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: red;
+  opacity: 0.4;
+  display: inline-block;
+  width: 30px;
+  height: 30px;
 }</style>`;
   }
 
@@ -27,4 +26,4 @@ Change the background-color and see if your page automatically refreshes.
 
 }
 
-customElements.define('high-light', HighLight);
+customElements.define('red-square', RedSquare);

--- a/test/dist/red-square.es5.js
+++ b/test/dist/red-square.es5.js
@@ -1,0 +1,62 @@
+"use strict";
+
+function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+
+function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function"); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, writable: true, configurable: true } }); if (superClass) _setPrototypeOf(subClass, superClass); }
+
+function _wrapNativeSuper(Class) { var _cache = typeof Map === "function" ? new Map() : undefined; _wrapNativeSuper = function _wrapNativeSuper(Class) { if (Class === null || !_isNativeFunction(Class)) return Class; if (typeof Class !== "function") { throw new TypeError("Super expression must either be null or a function"); } if (typeof _cache !== "undefined") { if (_cache.has(Class)) return _cache.get(Class); _cache.set(Class, Wrapper); } function Wrapper() { return _construct(Class, arguments, _getPrototypeOf(this).constructor); } Wrapper.prototype = Object.create(Class.prototype, { constructor: { value: Wrapper, enumerable: false, writable: true, configurable: true } }); return _setPrototypeOf(Wrapper, Class); }; return _wrapNativeSuper(Class); }
+
+function isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
+
+function _construct(Parent, args, Class) { if (isNativeReflectConstruct()) { _construct = Reflect.construct; } else { _construct = function _construct(Parent, args, Class) { var a = [null]; a.push.apply(a, args); var Constructor = Function.bind.apply(Parent, a); var instance = new Constructor(); if (Class) _setPrototypeOf(instance, Class.prototype); return instance; }; } return _construct.apply(null, arguments); }
+
+function _isNativeFunction(fn) { return Function.toString.call(fn).indexOf("[native code]") !== -1; }
+
+function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
+
+function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
+
+var RedSquare =
+/*#__PURE__*/
+function (_HTMLElement) {
+  _inherits(RedSquare, _HTMLElement);
+
+  function RedSquare() {
+    _classCallCheck(this, RedSquare);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(RedSquare).apply(this, arguments));
+  }
+
+  _createClass(RedSquare, [{
+    key: "connectedCallback",
+    value: function connectedCallback() {}
+  }]);
+
+  return RedSquare;
+}(_wrapNativeSuper(HTMLElement));
+
+"use strict";
+
+;
+
+(function () {
+  var style = document.createElement('style');
+  style.textContent = 'red-square {  background-color: red;  opacity: 0.4;  display: inline-block;  width: 30px;  height: 30px;}';
+  document.head.appendChild(style);
+})();
+
+"use strict";
+
+window.addEventListener('WebComponentsReady', function () {
+  customElements.define('red-square', RedSquare);
+});

--- a/test/dist/simple-bling.class.js
+++ b/test/dist/simple-bling.class.js
@@ -1,14 +1,33 @@
 class SimpleBling extends HTMLElement {
-  connectedCallback() {}
-
+  connectedCallback() {
+    this.attachShadow({
+      mode: 'open'
+    });
+    this.shadowRoot.innerHTML = `<slot></slot><style>:host {
+  background-color: black;
+  color: gold;
+  font-weight: bold;
+  padding: 0.25em;
 }
 
-;
+:host(:hover) {
+  background-color: gold;
+  color: black;
+}</style>`;
+  }
 
-(function () {
-  var style = document.createElement('style');
-  style.textContent = 'simple-bling {  background-color: black;  color: gold;  font-weight: bold;  padding: 0.25em;}simple-bling:hover {  background-color: gold;  color: black;}';
-  document.head.appendChild(style);
-})();
+  querySelector(selector) {
+    return this.shadowRoot.querySelector(selector);
+  }
+
+  querySelectorAll(selector) {
+    return this.shadowRoot.querySelectorAll(selector);
+  }
+
+  addEventListener() {
+    return this.shadowRoot.addEventListener.apply(this.shadowRoot, arguments);
+  }
+
+}
 
 customElements.define('simple-bling', SimpleBling);

--- a/test/src/group/blue-square.html
+++ b/test/src/group/blue-square.html
@@ -1,0 +1,24 @@
+<!--
+<template>
+  Structure the inside of your element
+</template>
+-->
+<style preprocessor="scss">
+:host {
+  background-color: blue;
+  opacity: .4;
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+}
+</style>
+<!--
+<script>
+  // Behavior in the form of a JS class
+  class BlueSquare {
+    connectedCallback() {
+      // ...
+    }
+  }
+</script>
+-->

--- a/test/src/group/multi-square.html
+++ b/test/src/group/multi-square.html
@@ -1,0 +1,30 @@
+<template>
+  <blue-square></blue-square>
+  <red-square></red-square>
+</template>
+<style preprocessor="scss">
+:host {
+  display: inline-block;
+  width: 45px;
+  height: 30px;
+  position: relative;
+}
+:host blue-square, :host red-square {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+:host blue-square {
+  left: 15px;
+}
+</style>
+<!--
+<script>
+  // Behavior in the form of a JS class
+  class MultiSquare {
+    connectedCallback() {
+      // ...
+    }
+  }
+</script>
+-->

--- a/test/src/group/red-square.html
+++ b/test/src/group/red-square.html
@@ -1,0 +1,24 @@
+<!--
+<template>
+  Structure the inside of your element
+</template>
+-->
+<style preprocessor="scss">
+:host {
+  background-color: red;
+  opacity: .4;
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+}
+</style>
+<!--
+<script>
+  // Behavior in the form of a JS class
+  class RedSquare {
+    connectedCallback() {
+      // ...
+    }
+  }
+</script>
+-->


### PR DESCRIPTION
slap a slot in there, and apply styles to the shadow DOM like we would for
more complex components.
This solves a rendering problem that is tested with the <multi-square> element.
When testing, those two squares should be seen to overlap.
The problem that simple elements were being styled with "light DOM" styles,
and when they appeared as children of another element, in its shadow DOM,
those inner elements weren't being styled.
We also always append the shadow DOM query and eventListener aliases,
so that all easy elements can behave in much the same way.